### PR TITLE
Feature/index manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1018,6 +1018,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-batch"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f5c372b0c5d1023cce2a0ff7667b589ba88dae751b5f65c400b5d0803b30cbf"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "pin-utils",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,6 +1100,12 @@ name = "futures-task"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
+
+[[package]]
+name = "futures-timer"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1de7508b218029b0f01662ed8f61b1c964b3ae99d6f25462d0f55a595109df6"
 
 [[package]]
 name = "futures-util"
@@ -1756,7 +1773,9 @@ dependencies = [
  "elasticsearch",
  "env_logger",
  "futures",
+ "futures-batch",
  "http",
+ "humantime",
  "log",
  "oas-common",
  "okapi",

--- a/rust/oas-common/src/record.rs
+++ b/rust/oas-common/src/record.rs
@@ -264,6 +264,15 @@ where
         self.value.resolve_refs(resolver).await
     }
 
+    /// Resolve all references, while consuming Self and returning it again with the resolved refs.
+    pub async fn into_resolve_refs<R: Resolver + Send + Sync>(
+        mut self,
+        resolver: &R,
+    ) -> Result<Self, MissingRefsError> {
+        let _ = self.value.resolve_refs(resolver).await?;
+        Ok(self)
+    }
+
     /// Extract all loaded referenced records from within the record, converting the references
     /// back to IDs.
     pub fn extract_refs(&mut self) -> Vec<UntypedRecord> {

--- a/rust/oas-common/src/resolver.rs
+++ b/rust/oas-common/src/resolver.rs
@@ -35,7 +35,7 @@ pub trait Resolver {
         &self,
         ids: &[&str],
     ) -> Vec<Result<Record<T>, Self::Error>> {
-        let futs: Vec<_> = ids.iter().map(|id| self.resolve(id)).collect();
+        let futs: Vec<_> = ids.into_iter().map(|id| self.resolve(id)).collect();
         let results = futures_util::future::join_all(futs).await;
         results
     }

--- a/rust/oas-core/Cargo.toml
+++ b/rust/oas-core/Cargo.toml
@@ -33,9 +33,11 @@ serde_json = "1.0.64"
 sha2 = "0.9.5"
 surf = "2.2.0"
 thiserror = "1.0.25"
-tokio = { version = "1", features = ["rt", "macros"]}
+tokio = { version = "1", features = ["rt", "macros", "time"]}
 url = "2.2.2"
 reqwest = "0.11.4"
 rocket_okapi = "0.7.0-alpha-1"
 schemars = "0.8.3"
 okapi = { version = "0.6.0-alpha-1" }
+futures-batch = "0.6.0"
+humantime = "2.1.0"

--- a/rust/oas-core/src/couch/resolver.rs
+++ b/rust/oas-core/src/couch/resolver.rs
@@ -11,3 +11,11 @@ impl Resolver for CouchDB {
         Ok(record)
     }
 }
+
+#[async_trait::async_trait]
+impl Resolver for &CouchDB {
+    type Error = CouchError;
+    async fn resolve<T: TypedValue>(&self, id: &str) -> Result<Record<T>, Self::Error> {
+        <CouchDB as Resolver>::resolve(self, id).await
+    }
+}

--- a/rust/oas-core/src/elastic.rs
+++ b/rust/oas-core/src/elastic.rs
@@ -8,14 +8,33 @@ use elasticsearch::{
     },
     BulkOperation, BulkParts, Elasticsearch, Error, DEFAULT_ADDRESS,
 };
-use elasticsearch::{SearchParts, UpdateByQueryParts};
+use elasticsearch::{GetParts, IndexParts, SearchParts, UpdateByQueryParts};
 use http::StatusCode;
 use oas_common::types::Post;
+use rocket::serde::DeserializeOwned;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use std::sync::Arc;
 use std::time::Instant;
 use url::Url;
 
 use oas_common::{ElasticMapping, Record, TypedValue, UntypedRecord};
+
+#[derive(thiserror::Error, Debug)]
+pub enum ElasticError {
+    #[error("Elasticsearch error: {0}")]
+    Elastic(#[from] elasticsearch::Error),
+    #[error("Elasticsearch exception: {:?}", .0.error())]
+    Exception(elasticsearch::http::response::Exception),
+    #[error("Other: {0}")]
+    Other(String),
+}
+
+impl From<elasticsearch::http::response::Exception> for ElasticError {
+    fn from(ex: elasticsearch::http::response::Exception) -> Self {
+        Self::Exception(ex)
+    }
+}
 
 /// ElasticSearch config.
 #[derive(Clap, Debug, Clone)]
@@ -27,16 +46,28 @@ pub struct Config {
     /// Elasticsearch index
     #[clap(long, env = "ELASTICSEARCH_INDEX")]
     pub index: String,
+
+    /// Elasticsearch index prefix
+    #[clap(long, env = "ELASTICSEARCH_PREFIX")]
+    pub prefix: Option<String>,
 }
 
 impl Config {
     /// Creates a new config with server URL and index name.
     pub fn new(url: Option<String>, index: String) -> Self {
-        Self { url, index }
+        Self {
+            url,
+            index,
+            prefix: None,
+        }
     }
     /// Creates config with index name and default values.
     pub fn with_default_url(index: String) -> Self {
-        Self { url: None, index }
+        Self {
+            url: None,
+            index,
+            prefix: None,
+        }
     }
 }
 
@@ -48,7 +79,7 @@ impl Config {
 /// you can find the documentation on [docs.rs](https://docs.rs/elasticsearch/7.12.1-alpha.1/elasticsearch/).
 #[derive(Debug, Clone)]
 pub struct Index {
-    client: Elasticsearch,
+    client: Arc<Elasticsearch>,
     index: String,
 }
 
@@ -56,14 +87,27 @@ impl Index {
     /// Creates a new client with config.
     pub fn with_config(config: Config) -> Result<Self, Error> {
         let client = create_client(config.url)?;
+        let client = Arc::new(client);
         Ok(Self {
             client,
             index: config.index,
         })
     }
 
+    pub fn with_client_and_name(client: Arc<Elasticsearch>, name: impl ToString) -> Self {
+        Self {
+            client: client,
+            index: name.to_string(),
+        }
+    }
+
     /// Get the index name.
     pub fn index(&self) -> &str {
+        &self.index
+    }
+
+    /// Get the index name.
+    pub fn name(&self) -> &str {
         &self.index
     }
 
@@ -82,11 +126,39 @@ impl Index {
         Ok(())
     }
 
+    pub async fn get_doc<T: DeserializeOwned>(&self, id: &str) -> Result<Option<T>, Error> {
+        let res = self
+            .client()
+            .get(GetParts::IndexId(self.name(), id))
+            .send()
+            .await?;
+        let mut json: serde_json::Value = res.json().await?;
+        if !json["found"].as_bool().unwrap() {
+            Ok(None)
+        } else {
+            let doc: T = serde_json::from_value(json["_source"].take())?;
+            Ok(Some(doc))
+        }
+    }
+
+    pub async fn put_doc<T: Serialize>(&self, id: &str, doc: &T) -> Result<(), Error> {
+        let _res = self
+            .client()
+            .index(IndexParts::IndexId(self.name(), id))
+            .body(doc)
+            .send()
+            .await?;
+        Ok(())
+    }
+
     /// Put a list of [Record]s to the index.
     ///
     /// Internally the [Record]s are transformed to [UntypedRecord]s, serialized and saved in a
     /// single bulk operation.
-    pub async fn put_typed_records<T: TypedValue>(&self, docs: &[Record<T>]) -> Result<(), Error> {
+    pub async fn put_typed_records<T: TypedValue>(
+        &self,
+        docs: &[Record<T>],
+    ) -> Result<(), ElasticError> {
         let docs: Vec<UntypedRecord> = docs
             .iter()
             .filter_map(|r| r.clone().into_untyped_record().ok())
@@ -96,7 +168,7 @@ impl Index {
     }
 
     /// Put a list of [UntypedRecord]s to the index
-    pub async fn put_untyped_records(&self, docs: &[UntypedRecord]) -> Result<(), Error> {
+    pub async fn put_untyped_records(&self, docs: &[UntypedRecord]) -> Result<(), ElasticError> {
         self.set_refresh_interval(json!("-1")).await?;
         let now = Instant::now();
 
@@ -215,11 +287,35 @@ for (nested_doc in nested_docs) {
     }
 }
 
+/// Check if an Elasticsearch response contains an error, and if so, parse the Elasticsearch
+/// exception JSON payload (if possible).
+///
+/// TODO: Move into an extension trait for Response
+async fn check_error(
+    response: elasticsearch::http::response::Response,
+) -> Result<elasticsearch::http::response::Response, ElasticError> {
+    let status_code_err = response.error_for_status_code_ref();
+    if let Err(status_code_err) = status_code_err {
+        let ex = response.exception().await?;
+        if let Some(ex) = ex {
+            Err(ex.into())
+        } else {
+            Err(status_code_err.into())
+        }
+    } else {
+        Ok(response)
+    }
+}
+
 async fn index_records(
     client: &Elasticsearch,
     index_name: &str,
     posts: &[UntypedRecord],
-) -> Result<(), Error> {
+) -> Result<BulkPutResponse, ElasticError> {
+    if posts.is_empty() {
+        return Ok(BulkPutResponse::default());
+    }
+
     let body: Vec<BulkOperation<_>> = posts
         .iter()
         .map(|r| {
@@ -234,25 +330,29 @@ async fn index_records(
         .send()
         .await?;
 
-    let json: Value = response.json().await?;
+    let response = check_error(response).await?;
+    let results: BulkPutResponse = response.json().await?;
 
-    let len = json["items"].as_array().unwrap().len();
-
-    if json["errors"].as_bool().unwrap() {
-        let failed: Vec<&Value> = json["items"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .filter(|v| !v["error"].is_null())
-            .collect();
-
-        // TODO: retry failures
-        log::error!("Errors whilst indexing. Failures: {}", failed.len());
-    }
-    log::info!("Indexed {} records", len);
-
-    Ok(())
+    Ok(results)
 }
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct BulkPutResponse {
+    took: u32,
+    errors: bool,
+    items: Vec<BulkPutResponseAction>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BulkPutResponseAction {
+    Create(BulkPutResponseItem),
+    Delete(BulkPutResponseItem),
+    Index(BulkPutResponseItem),
+    Update(BulkPutResponseItem),
+}
+
+pub type BulkPutResponseItem = oas_common::Object;
 
 async fn create_index_if_not_exists(
     client: &Elasticsearch,
@@ -298,7 +398,7 @@ async fn create_index_if_not_exists(
     Ok(())
 }
 
-fn create_client(addr: Option<String>) -> Result<Elasticsearch, Error> {
+pub fn create_client(addr: Option<String>) -> Result<Elasticsearch, Error> {
     fn default_addr() -> String {
         match std::env::var("ELASTICSEARCH_URL") {
             Ok(server) => server,

--- a/rust/oas-core/src/index/error.rs
+++ b/rust/oas-core/src/index/error.rs
@@ -1,0 +1,15 @@
+#[derive(thiserror::Error, Debug)]
+pub enum IndexError {
+    #[error("Elasticsearch error: {0}")]
+    Elastic(#[from] elasticsearch::Error),
+    #[error("Elasticsearch exception: {:?}", .0.error())]
+    Exception(elasticsearch::http::response::Exception),
+    #[error("Other: {0}")]
+    Other(String),
+}
+
+impl From<elasticsearch::http::response::Exception> for IndexError {
+    fn from(ex: elasticsearch::http::response::Exception) -> Self {
+        Self::Exception(ex)
+    }
+}

--- a/rust/oas-core/src/index/manager.rs
+++ b/rust/oas-core/src/index/manager.rs
@@ -160,7 +160,6 @@ async fn index_changes_stream(
         let len = batch.len();
         let latest_seq = &batch.last().unwrap().seq.to_string();
         index_changes_batch(db, index, batch).await?;
-        eprintln!("indexed {}, store latest seq {}", len, latest_seq);
         meta.set_latest_indexed_seq(latest_seq).await?;
     }
 
@@ -236,10 +235,10 @@ pub async fn index_changes_batch(
         index.update_nested_record("media", &media_record).await?;
     }
     log::debug!(
-        "indexed {} posts, {} media updates in {}",
+        "indexed {} posts, {} media updates in {}ms",
         post_batch.len(),
         media_batch.len(),
-        humantime::format_duration(start.elapsed())
+        start.elapsed().as_millis()
     );
     Ok(())
 }

--- a/rust/oas-core/src/index/manager.rs
+++ b/rust/oas-core/src/index/manager.rs
@@ -1,0 +1,274 @@
+//! Index manager
+//!
+//! The index manager maintains a list of Elasticsearch indexes. It also maintains an "oas.meta"
+//! index which stores meta information about the indexing state, most importantly the latest
+//! CouchDB seq that was indexed.
+
+use crate::couch::{self, ChangesStream, CouchDB};
+use elasticsearch::{Elasticsearch, GetParts, IndexParts};
+use futures::stream::StreamExt;
+use futures_batch::ChunksTimeoutStreamExt;
+use oas_common::types::{Media, Post};
+use oas_common::{Record, TypedValue};
+use oas_common::{Resolver, UntypedRecord};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::time;
+
+use super::index::{self as elastic, Index};
+
+pub const DEFAULT_PREFIX: &str = "oas";
+pub const META_INDEX_NAME: &str = "_meta";
+
+pub const DATA_INDEX_NAME: &str = "data";
+
+pub const DOC_ID_INDEX_STATE: &str = "IndexMeta.data";
+
+pub type IndexId = String;
+pub type Seq = String;
+
+#[derive(Debug, Clone)]
+pub struct IndexManager {
+    config: elastic::Config,
+    meta: Arc<Meta>,
+    client: Arc<Elasticsearch>,
+    data_index: Arc<elastic::Index>, // indexes: HashMap<IndexId, elastic::Index>,
+}
+
+#[derive(Debug)]
+pub struct Meta {
+    index: elastic::Index,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct InitOpts {
+    delete_meta: bool,
+    delete_data: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct IndexState {
+    last_seq: Option<String>,
+}
+
+impl Default for InitOpts {
+    fn default() -> Self {
+        Self {
+            delete_meta: false,
+            delete_data: false,
+        }
+    }
+}
+
+impl InitOpts {
+    pub fn delete_all() -> Self {
+        Self {
+            delete_meta: true,
+            delete_data: true,
+        }
+    }
+
+    pub fn delete_data() -> Self {
+        Self {
+            delete_meta: false,
+            delete_data: true,
+        }
+    }
+}
+
+impl Meta {
+    pub fn with_index(index: elastic::Index) -> Self {
+        Self { index }
+    }
+
+    pub async fn latest_indexed_seq(&self) -> anyhow::Result<Option<Seq>> {
+        let id = DOC_ID_INDEX_STATE;
+        let doc = self.index.get_doc::<IndexState>(id).await?;
+        if let Some(index_state) = doc {
+            Ok(index_state.last_seq)
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub async fn set_latest_indexed_seq(&self, seq: &Seq) -> anyhow::Result<()> {
+        let id = DOC_ID_INDEX_STATE;
+        let index_state = IndexState {
+            last_seq: Some(seq.to_string()),
+        };
+        self.index.put_doc(id, &index_state).await?;
+        Ok(())
+    }
+}
+
+impl IndexManager {
+    pub fn with_config(config: elastic::Config) -> Result<Self, elasticsearch::Error> {
+        let client = elastic::create_client(config.url.clone())?;
+        let client = Arc::new(client);
+
+        let prefix = config.prefix.as_deref().unwrap_or(DEFAULT_PREFIX);
+        let meta_index_name = format!("{}.{}", prefix, META_INDEX_NAME);
+        let meta_index = Index::with_client_and_name(client.clone(), meta_index_name);
+        let meta = Meta::with_index(meta_index);
+
+        let data_index_name = format!("{}.{}", prefix, DATA_INDEX_NAME);
+        let data_index = Index::with_client_and_name(client.clone(), data_index_name);
+
+        Ok(Self {
+            config,
+            client,
+            data_index: Arc::new(data_index),
+            meta: Arc::new(meta),
+        })
+    }
+
+    pub async fn init(&self, opts: InitOpts) -> anyhow::Result<()> {
+        self.meta.index.ensure_index(opts.delete_meta).await?;
+        self.data_index.ensure_index(opts.delete_data).await?;
+        Ok(())
+    }
+
+    pub fn data_index(&self) -> &Arc<elastic::Index> {
+        &self.data_index
+    }
+
+    pub async fn index_changes(&self, db: &CouchDB, mode: bool) -> anyhow::Result<()> {
+        let index = self.data_index();
+        let meta = &self.meta;
+        index_changes_stream(&db, &meta, &index, mode).await
+    }
+}
+
+async fn index_changes_stream(
+    db: &CouchDB,
+    meta: &Arc<Meta>,
+    index: &Arc<Index>,
+    infinite: bool,
+) -> anyhow::Result<()> {
+    let latest_seq = meta.latest_indexed_seq().await?;
+    let mut changes = db.changes(latest_seq);
+    changes.set_infinite(infinite);
+
+    let batch_timeout = time::Duration::from_millis(200);
+    let batch_max_len = 1000;
+
+    let mut batched_changes = changes.chunks_timeout(batch_max_len, batch_timeout);
+
+    while let Some(batch) = batched_changes.next().await {
+        // Filter out errors for now.
+        let batch: Vec<_> = batch.into_iter().filter_map(|e| e.ok()).collect();
+        let len = batch.len();
+        let latest_seq = &batch.last().unwrap().seq.to_string();
+        index_changes_batch(db, index, batch).await?;
+        eprintln!("indexed {}, store latest seq {}", len, latest_seq);
+        meta.set_latest_indexed_seq(latest_seq).await?;
+    }
+
+    Ok(())
+}
+
+pub async fn posts_into_resolved_posts_and_updated_media_batches(
+    db: &CouchDB,
+    records: Vec<(UntypedRecord, bool)>,
+) -> (Vec<Record<Post>>, Vec<UntypedRecord>) {
+    let mut post_batch = vec![];
+    let mut media_batch = vec![];
+    for (record, is_first_rev) in records.into_iter() {
+        match record.typ() {
+            Media::NAME => {
+                if !is_first_rev {
+                    media_batch.push(record);
+                }
+            }
+            Post::NAME => {
+                let record = record.into_typed_record::<Post>();
+                match record {
+                    Ok(mut record) => {
+                        post_batch.push(record)
+                        // TODO: Resolve in parallel.
+                        // let _res = record.resolve_refs(&db).await;
+                        // post_batch.push(record);
+                    }
+                    Err(e) => log::debug!("{}", e),
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let resolve_posts_fut: Vec<_> = post_batch
+        .into_iter()
+        .map(|record| record.into_resolve_refs(&db))
+        .collect();
+    let post_batch: Vec<_> = futures::future::join_all(resolve_posts_fut)
+        .await
+        .into_iter()
+        .filter_map(|r| r.ok())
+        .collect();
+    (post_batch, media_batch)
+}
+
+pub async fn index_changes_batch(
+    db: &CouchDB,
+    index: &Arc<Index>,
+    changes: Vec<couch::ChangeEvent>,
+) -> anyhow::Result<()> {
+    let start = time::Instant::now();
+    let records_and_is_first_rev: Vec<_> = changes
+        .into_iter()
+        .filter_map(|event| match event.doc {
+            None => None,
+            Some(doc) => {
+                let is_first_rev = doc.is_first_rev().unwrap_or(true);
+                match doc.into_untyped_record() {
+                    Err(_) => None,
+                    Ok(record) => Some((record, is_first_rev)),
+                }
+            }
+        })
+        .collect();
+
+    let (post_batch, media_batch) =
+        posts_into_resolved_posts_and_updated_media_batches(&db, records_and_is_first_rev).await;
+    let _res = index.put_typed_records(&post_batch).await?;
+    // TODO: parallelize?
+    for media_record in media_batch.iter() {
+        index.update_nested_record("media", &media_record).await?;
+    }
+    log::debug!(
+        "indexed {} posts, {} media updates in {}",
+        post_batch.len(),
+        media_batch.len(),
+        humantime::format_duration(start.elapsed())
+    );
+    Ok(())
+}
+
+// TODO: Maybe rewrite the loop above onto a struct.
+// pub struct ChangesIndexer {
+//     stream: ChangesStream,
+//     index: Arc<elastic::Index>,
+//     interval: tokio::time::Interval,
+//     batch: Vec<Record<Post>>,
+//     max_batch: usize,
+//     total: usize,
+// }
+// pub enum StreamMode {
+//     Finite,
+//     Infinite,
+// }
+
+// impl From<bool> for StreamMode {
+//     fn from(infinite: bool) -> Self {
+//         match infinite {
+//             true => Self::Infinite,
+//             false => Self::Finite,
+//         }
+//     }
+// }
+
+// impl Default for StreamMode {
+//     fn default() -> Self {
+//         Self::Finite
+//     }
+// }

--- a/rust/oas-core/src/index/mod.rs
+++ b/rust/oas-core/src/index/mod.rs
@@ -1,0 +1,7 @@
+mod error;
+mod index;
+mod manager;
+
+pub use error::IndexError;
+pub use index::{Config, Index};
+pub use manager::{IndexManager, InitOpts};

--- a/rust/oas-core/src/lib.rs
+++ b/rust/oas-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod couch;
 pub mod elastic;
+pub mod index;
 pub mod rss;
 pub mod server;
 pub mod tasks;
@@ -14,7 +15,9 @@ pub use oas_common::*;
 #[derive(Clone, Debug)]
 pub struct State {
     pub db: couch::CouchDB,
+    // todo: remove!
     pub index: elastic::Index,
+    pub index_manager: index::IndexManager,
 }
 
 impl State {

--- a/rust/oas-core/src/lib.rs
+++ b/rust/oas-core/src/lib.rs
@@ -1,5 +1,4 @@
 pub mod couch;
-pub mod elastic;
 pub mod index;
 pub mod rss;
 pub mod server;
@@ -15,8 +14,6 @@ pub use oas_common::*;
 #[derive(Clone, Debug)]
 pub struct State {
     pub db: couch::CouchDB,
-    // todo: remove!
-    pub index: elastic::Index,
     pub index_manager: index::IndexManager,
 }
 
@@ -26,7 +23,7 @@ impl State {
     /// Currently errors on the first failing init.
     pub async fn init_all(&self) -> anyhow::Result<()> {
         self.db.init().await?;
-        self.index.ensure_index(false).await?;
+        self.index_manager.init(Default::default()).await?;
         Ok(())
     }
 }

--- a/rust/oas-core/src/server/handlers/search.rs
+++ b/rust/oas-core/src/server/handlers/search.rs
@@ -18,8 +18,8 @@ pub async fn search(
         ));
     }
 
-    let index = &state.index;
-    let client = index.client();
+    let index = &state.index_manager.data_index();
+    let client = &index.client();
 
     let path = format!("{}/{}", index.index(), search_method);
     let res = client


### PR DESCRIPTION
* Adds an index manager struct that maintains, for now, the data (Post) index and a meta index
* Saves the latest couch seq that was indexed in the meta index, to resume indexing where it left
* Move elasticsearch things into a `index` module