### PR TITLE
Add mediaproxy, include frontend in binary, improve HTTP error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,6 +1436,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31a924bd335356c7622dff9ee33d06920afcf7f762a1a991236645e08c8a484b"
+dependencies = [
+ "glob",
+ "include_dir_impl",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "include_dir_impl"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afae3917f781921d7c7813992ccadff7e816f7e6ecb4b70a9ec3e740d51da3d6"
+dependencies = [
+ "anyhow",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1768,6 +1792,7 @@ dependencies = [
  "async-trait",
  "base32",
  "base64 0.13.0",
+ "bytes 1.0.1",
  "celery",
  "chrono",
  "clap",
@@ -1777,6 +1802,7 @@ dependencies = [
  "futures-batch",
  "http",
  "humantime",
+ "include_dir",
  "log",
  "oas-common",
  "okapi",

--- a/Dockerfile-core
+++ b/Dockerfile-core
@@ -20,6 +20,7 @@ FROM base as builder
 WORKDIR app
 COPY Cargo.toml .
 COPY rust rust
+COPY frontend frontend
 # copy the built dependencies from previous image
 COPY --from=cacher /app/target target
 COPY --from=cacher /usr/local/cargo /usr/local/cargo

--- a/rust/oas-core/Cargo.toml
+++ b/rust/oas-core/Cargo.toml
@@ -35,7 +35,7 @@ surf = "2.2.0"
 thiserror = "1.0.25"
 tokio = { version = "1", features = ["rt", "macros", "time", "signal"]}
 url = "2.2.2"
-reqwest = "0.11.4"
+reqwest = { version = "0.11.4", features = ["stream"] }
 rocket_okapi = "0.7.0-alpha-1"
 schemars = "0.8.3"
 okapi = { version = "0.6.0-alpha-1" }
@@ -43,3 +43,5 @@ tokio-stream = "0.1"
 futures-batch = "0.6.0"
 humantime = "2.1.0"
 chrono = "0.4.19"
+bytes = "1.0.1"
+include_dir = "0.6.1"

--- a/rust/oas-core/build.rs
+++ b/rust/oas-core/build.rs
@@ -1,0 +1,30 @@
+use std::process::Command;
+const FRONTEND_PATH: &str = "../../frontend";
+const FRONTEND_DIST_PATH: &str = "../../frontend/dist";
+fn main() {
+    println!("cargo:rerun-if-changed={}/src", FRONTEND_PATH);
+    println!("cargo:rerun-if-env-changed={}", "BUILD_FRONTEND");
+    println!("cargo:rerun-if-env-changed={}", "PROFILE");
+    let build_frontend = match std::env::var("BUILD_FRONTEND") {
+        Ok(_) => true,
+        Err(_) => match std::env::var("PROFILE").unwrap().as_str() {
+            "release" => true,
+            "debug" => false,
+            _ => false,
+        },
+    };
+    if build_frontend {
+        // In release mode, build the frontend using yarn. The result will be included statically
+        // in the binary.
+        Command::new("yarn")
+            .current_dir(FRONTEND_PATH)
+            .arg("build")
+            .status()
+            .expect("Failed to build frontend");
+    } else {
+        // On debug builds, don't rebuild the frontend but ensure that the directory is present.
+        // Otherwise the build will fail because in src/server/mod.rs the frontend/dist directory
+        // is statically included.
+        std::fs::create_dir_all(FRONTEND_DIST_PATH).expect("Failed to create frontend dist dir.");
+    }
+}

--- a/rust/oas-core/src/couch/error.rs
+++ b/rust/oas-core/src/couch/error.rs
@@ -8,8 +8,8 @@ use super::types::ErrorDetails;
 pub enum CouchError {
     #[error("HTTP: {0}")]
     Http(surf::Error),
-    #[error("CouchDB: {0}")]
-    Couch(#[from] ErrorDetails),
+    #[error("CouchDB: {1}")]
+    Couch(surf::StatusCode, ErrorDetails),
     #[error("Serialization: {0}")]
     Json(#[from] serde_json::Error),
     #[error("IO: {0}")]
@@ -18,6 +18,16 @@ pub enum CouchError {
     DecodingError(#[from] DecodingError),
     #[error("{0}")]
     Other(String),
+}
+
+impl CouchError {
+    pub fn status_code(&self) -> Option<u16> {
+        match self {
+            Self::Http(err) => Some(err.status().into()),
+            Self::Couch(status, _) => Some((*status).into()),
+            _ => None,
+        }
+    }
 }
 
 impl From<surf::Error> for CouchError {

--- a/rust/oas-core/src/couch/mod.rs
+++ b/rust/oas-core/src/couch/mod.rs
@@ -277,7 +277,10 @@ impl CouchDB {
         let mut res = self.client.send(request).await?;
         match res.status().is_success() {
             true => Ok(res.body_json::<T>().await?),
-            false => Err(res.body_json::<ErrorDetails>().await?.into()),
+            false => Err(CouchError::Couch(
+                res.status(),
+                res.body_json::<ErrorDetails>().await?,
+            )),
         }
     }
 }

--- a/rust/oas-core/src/server/handlers/mod.rs
+++ b/rust/oas-core/src/server/handlers/mod.rs
@@ -1,5 +1,4 @@
 pub mod feed;
-// pub mod legacy;
 pub mod media;
 pub mod record;
 pub mod search;

--- a/rust/oas-core/src/server/proxy.rs
+++ b/rust/oas-core/src/server/proxy.rs
@@ -1,0 +1,197 @@
+use futures::stream::StreamExt;
+use reqwest::header;
+use rocket::http::Status;
+use rocket::http::{HeaderMap, Method};
+use rocket::request::FromRequest;
+use rocket::response::stream::{ByteStream, ReaderStream};
+use rocket::route::{Handler, Outcome, Route};
+use rocket::Data;
+use std::ops::Deref;
+
+/// List of headers to forward on proxy requests.
+pub static HEADERS_REQUEST: [reqwest::header::HeaderName; 10] = [
+    header::CONTENT_TYPE,
+    header::CONTENT_LENGTH,
+    header::CONTENT_RANGE,
+    header::ACCEPT_RANGES,
+    header::PRAGMA,
+    header::EXPIRES,
+    header::DATE,
+    header::CACHE_CONTROL,
+    header::ETAG,
+    header::LAST_MODIFIED,
+];
+
+/// List of headers to forward on proxy responses.
+pub static HEADERS_RESPONSE: [reqwest::header::HeaderName; 9] = [
+    reqwest::header::RANGE,
+    reqwest::header::CONTENT_TYPE,
+    reqwest::header::IF_MATCH,
+    reqwest::header::IF_RANGE,
+    reqwest::header::IF_MODIFIED_SINCE,
+    reqwest::header::IF_UNMODIFIED_SINCE,
+    reqwest::header::ETAG,
+    reqwest::header::ACCEPT,
+    reqwest::header::ACCEPT_ENCODING,
+];
+
+/// Responder struct to forward a reqwest response as a stream
+/// while copying the status code and some headers.
+pub struct ReqwestResponse {
+    res: reqwest::Response,
+}
+
+impl ReqwestResponse {
+    pub fn new(res: reqwest::Response) -> Self {
+        Self { res }
+    }
+}
+
+impl From<reqwest::Response> for ReqwestResponse {
+    fn from(res: reqwest::Response) -> Self {
+        Self::new(res)
+    }
+}
+
+impl<'r> rocket::response::Responder<'r, 'r> for ReqwestResponse {
+    fn respond_to(self, _: &'r rocket::Request<'_>) -> rocket::response::Result<'r> {
+        let mut res = rocket::response::Response::build().finalize();
+        // Copy over header values.
+        copy_response_headers(&self.res, &mut res, &HEADERS_RESPONSE);
+        // Copy status code.
+        res.set_status(rocket::http::Status::new(self.res.status().as_u16()));
+
+        // Pass through the body stream, with some required type juggling.
+        // TODO: The reqwest body stream can error at any type. Returning None in the map will
+        // likely work, but rocket's byte stream also has a shutdown mechanism that might be more
+        // appropriate.
+        let stream = self.res.bytes_stream();
+        let stream = stream.filter_map(|item| async move { item.ok() });
+        let stream = ByteStream::from(stream);
+        let stream = stream.0.map(std::io::Cursor::new);
+        res.set_streamed_body(ReaderStream::from(stream));
+        Ok(res)
+    }
+}
+
+/// Copy headers from a rocket request into a reqwest request.
+pub fn copy_request_headers(
+    in_headers: &rocket::http::HeaderMap,
+    out_req: &mut reqwest::Request,
+    headers: &[reqwest::header::HeaderName],
+) {
+    for header_name in headers {
+        for header_value in in_headers.get(header_name.as_str()) {
+            let value = header_value.parse::<reqwest::header::HeaderValue>();
+            if let Ok(value) = value {
+                out_req.headers_mut().append(header_name, value);
+            }
+        }
+    }
+}
+
+/// Copy headers from a reqwest response into a rocket response.
+pub fn copy_response_headers(
+    in_res: &reqwest::Response,
+    out_res: &mut rocket::response::Response,
+    headers: &[reqwest::header::HeaderName],
+) {
+    for header_name in headers {
+        if let Some(header_value) = in_res.headers().get(header_name) {
+            if let Ok(header_value) = String::from_utf8(header_value.as_bytes().to_vec()) {
+                out_res.set_header(rocket::http::Header::new(
+                    header_name.to_string(),
+                    header_value,
+                ));
+            }
+        }
+    }
+}
+
+const DEFAULT_RANK: isize = 5;
+
+/// A route handler that proxies all requests to a target http or https server.
+#[derive(Clone)]
+pub struct ProxyHandler {
+    client: reqwest::Client,
+    target: String,
+    rank: isize,
+}
+
+impl Into<Vec<Route>> for ProxyHandler {
+    fn into(self) -> Vec<Route> {
+        let mut routes = vec![
+            Route::ranked(self.rank, Method::Get, "/<path..>", self.clone()),
+            Route::ranked(self.rank, Method::Put, "/<path..>", self.clone()),
+            Route::ranked(self.rank, Method::Post, "/<path..>", self.clone()),
+            Route::ranked(self.rank, Method::Patch, "/<path..>", self.clone()),
+            Route::ranked(self.rank, Method::Head, "/<path..>", self.clone()),
+            Route::ranked(self.rank, Method::Delete, "/<path..>", self.clone()),
+        ];
+        for route in routes.iter_mut() {
+            route.name = Some(format!("Proxy({})", self.target).into());
+        }
+        routes
+    }
+}
+
+impl ProxyHandler {
+    /// Create a proxy handler to the specified target URL.
+    /// The incoming request's path and querystring will be appended to this URL.
+    /// It should not contain a trailing slash.
+    pub fn new(target: String) -> Self {
+        Self::with_rank(target, DEFAULT_RANK)
+    }
+
+    pub fn with_rank(target: String, rank: isize) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            target,
+            rank,
+        }
+    }
+}
+
+fn convert_method_rocket_reqwest(method: rocket::http::Method) -> reqwest::Method {
+    reqwest::Method::from_bytes(method.as_str().as_bytes()).unwrap()
+}
+
+#[async_trait::async_trait]
+impl Handler for ProxyHandler {
+    async fn handle<'r>(&self, req: &'r rocket::Request<'_>, data: Data<'r>) -> Outcome<'r> {
+        let url = format!("{}{}", self.target, req.uri());
+        let method = convert_method_rocket_reqwest(req.method());
+        let out_req = self.client.request(method, url).build();
+        let mut out_req = match out_req {
+            Ok(req) => req,
+            Err(_err) => return Outcome::failure(Status::BadGateway),
+        };
+        copy_request_headers(req.headers(), &mut out_req, &HEADERS_REQUEST);
+        let res = self.client.execute(out_req).await;
+        match res {
+            Ok(res) => Outcome::from_or_forward(&req, data, ReqwestResponse::new(res)),
+            Err(_err) => Outcome::failure(Status::BadGateway),
+        }
+    }
+}
+
+/// Request guard to get a request's headers.
+pub struct Headers<'r>(pub &'r HeaderMap<'r>);
+
+impl<'r> Deref for Headers<'r> {
+    type Target = HeaderMap<'r>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[async_trait::async_trait]
+impl<'r> FromRequest<'r> for Headers<'r> {
+    type Error = ();
+    async fn from_request(
+        request: &'r rocket::Request<'_>,
+    ) -> rocket::request::Outcome<Self, Self::Error> {
+        let headers = request.headers();
+        rocket::request::Outcome::Success(Self(headers))
+    }
+}

--- a/rust/oas-core/src/server/static_dir.rs
+++ b/rust/oas-core/src/server/static_dir.rs
@@ -1,0 +1,94 @@
+use rocket::http::ContentType;
+use rocket::http::{uri::Segments, Method};
+use rocket::response::Responder;
+use rocket::route::{Handler, Outcome, Route};
+use rocket::{Data, Request, Response};
+use std::path::PathBuf;
+
+const DEFAULT_RANK: isize = 10;
+
+#[derive(Clone, Debug)]
+pub struct IncludedStaticDir {
+    rank: isize,
+    dir: &'static include_dir::Dir<'static>,
+}
+
+impl IncludedStaticDir {
+    pub fn new(dir: &'static include_dir::Dir) -> Self {
+        Self {
+            rank: DEFAULT_RANK,
+            dir,
+        }
+    }
+}
+
+impl Into<Vec<Route>> for IncludedStaticDir {
+    fn into(self) -> Vec<Route> {
+        let mut route = Route::ranked(self.rank, Method::Get, "/<path..>", self);
+        route.name = Some(format!("IncludedStaticDir").into());
+        vec![route]
+    }
+}
+
+#[async_trait::async_trait]
+impl Handler for IncludedStaticDir {
+    async fn handle<'r>(&self, req: &'r rocket::Request<'_>, data: Data<'r>) -> Outcome<'r> {
+        use rocket::http::uri::fmt::Path;
+
+        let path = req
+            .segments::<Segments<'_, Path>>(0..)
+            .ok()
+            .and_then(|segments| segments.to_path_buf(true).ok());
+
+        match path {
+            Some(mut path) => {
+                if path.to_str() == Some("") || path.is_dir() {
+                    path.push("index.html");
+                }
+                serve_from_included_static_dir(req, data, &self.dir, path)
+            }
+            None => Outcome::forward(data),
+        }
+    }
+}
+
+fn serve_from_included_static_dir<'r>(
+    req: &'r rocket::Request<'_>,
+    data: Data<'r>,
+    dir: &'static include_dir::Dir,
+    path: PathBuf,
+) -> Outcome<'r> {
+    let file = dir.get_file(&path);
+    if let Some(file) = file {
+        Outcome::from_or_forward(req, data, StaticFile::new(path, file))
+    } else {
+        Outcome::forward(data)
+    }
+}
+
+pub struct StaticFile {
+    path: PathBuf,
+    file: include_dir::File<'static>,
+}
+
+impl StaticFile {
+    pub fn new(path: PathBuf, file: include_dir::File<'static>) -> Self {
+        Self { path, file }
+    }
+}
+
+impl<'r> Responder<'r, 'static> for StaticFile {
+    fn respond_to(self, _req: &'r Request<'_>) -> rocket::response::Result<'static> {
+        let body = self.file.contents();
+        let len = body.len();
+        let body = std::io::Cursor::new(body);
+        let mut response = Response::build().sized_body(len, body).finalize();
+        if let Some(ext) = self.path.extension() {
+            if let Some(ct) = ContentType::from_extension(&ext.to_string_lossy()) {
+                response.set_header(ct);
+            }
+        }
+
+        Ok(response)
+    }
+}


### PR DESCRIPTION
- Add a proxy responder and handler
- Add a handler that statically inlcudes a folder of files into the
  binary at build time and serve that on a route
- Use the proxy or static handler to either serve the frontend from the
  binary (included at build time) or proxy to a frontend proxy.
- Add a media proxy to serve proxied media files
- Improve HTTP error handling for various errors