### PR TITLE
Fix index mapping and reduce payload size

### DIFF
--- a/rust/oas-common/src/types/feed.rs
+++ b/rust/oas-common/src/types/feed.rs
@@ -17,6 +17,7 @@ pub struct FeedSettings {
     /// Interval to check for feed updates (in seconds)
     pub check_interval: u64,
     /// Try to crawl the feed backwards by increasing an offset query parameter
+    #[serde(default)]
     pub crawl_backwards: bool,
 }
 

--- a/rust/oas-common/src/types/media.rs
+++ b/rust/oas-common/src/types/media.rs
@@ -83,10 +83,17 @@ impl ElasticMapping for Media {
                 "type": "object",
                 "enabled": false
             },
+            "transcript": {
+                "type": "object",
+                "enabled": false
+            },
             "contentUrl":{
-                "type":"text",
+                "type":"text"
             },
             "duration": {
+                "type": "float"
+            },
+            "contentSize": {
                 "type": "float"
             },
             "encodingFormat": {
@@ -95,9 +102,12 @@ impl ElasticMapping for Media {
             "nlp": {
                 "type": "object"
             },
-            "transcript": {
-                "type": "object"
-            }
+            "posts": {
+                "type": "keyword"
+            },
+            "feeds": {
+                "type": "keyword"
+            },
         })
     }
 }

--- a/rust/oas-common/src/types/post.rs
+++ b/rust/oas-common/src/types/post.rs
@@ -166,13 +166,7 @@ impl ElasticMapping for Post {
                 }
             },
             "identifier":{
-                "type":"text",
-                "fields":{
-                    "keyword":{
-                        "type":"keyword",
-                        "ignore_above":256
-                    }
-                }
+                "type":"keyword",
             },
             "inLanguage":{
                 "type":"text",

--- a/rust/oas-core/src/index/post_index.rs
+++ b/rust/oas-core/src/index/post_index.rs
@@ -147,10 +147,20 @@ impl PostIndex {
             _ => {}
         }
 
-        // Build the transcript for a post.
         for post in posts.iter_mut() {
+            // Build the transcript for a post.
             if let Some(transcript) = generate_transcript_for_post(&post) {
                 post.value.transcript = Some(transcript);
+            }
+
+            // Don't index the original transcript.
+            for media in post
+                .value
+                .media
+                .iter_mut()
+                .filter_map(|media| media.record_mut())
+            {
+                media.value.transcript = None;
             }
         }
 

--- a/rust/oas-core/src/rss/manager.rs
+++ b/rust/oas-core/src/rss/manager.rs
@@ -61,6 +61,10 @@ impl FeedManager {
     pub async fn run_watch(self, db: CouchDB) -> anyhow::Result<()> {
         run_watch(self, db).await
     }
+
+    // pub async fn run_crawl(self, db: CouchDB) -> anyhow::Result<()> {
+    // run_crawl(self, db).await
+    // }
 }
 
 #[derive(Debug)]
@@ -117,6 +121,7 @@ impl FeedManagerInner {
         Ok(())
     }
 }
+
 async fn run_watch(manager: FeedManager, db: CouchDB) -> anyhow::Result<()> {
     let tasks = start_feed_tasks(&manager, db.clone()).await?;
     let mapping = {


### PR DESCRIPTION
This removes the raw transcript (the array with `{ word, start, end, conf }`) from the media records embedded in posts before indexing. We only use the transcript field on post which is generated before indexing also. This greatly reduces the size of elasticsearch responses.

Likely there's more things we don't need in elasticsearch.