### PR TITLE
Try to build a custom search box without autosuggest

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "GPL-3.0",
   "dependencies": {
-    "@appbaseio/reactivesearch": "^3.17.0",
+    "@appbaseio/reactivesearch": "^3.22.0",
     "@chakra-ui/react": "^1.6.4",
     "@emotion/react": "^11",
     "@emotion/styled": "^11",

--- a/frontend/src/comp/landing-page.jsx
+++ b/frontend/src/comp/landing-page.jsx
@@ -6,12 +6,10 @@ import { Link, useHistory } from 'react-router-dom'
 import Moment from 'moment'
 import { useTranslation } from 'react-i18next'
 import { PostButtons } from './post'
-import { ResultItem } from './search'
+import { ResultItem, GoToSearchBox } from './search'
 
 export default function LandingPage () {
   const url = API_ENDPOINT + '/search'
-  const [value, setValue] = React.useState('')
-  const history = useHistory()
   const { t } = useTranslation()
   return (
     <Center>
@@ -26,24 +24,7 @@ export default function LandingPage () {
               <Heading as='h2' size='lg' fontWeight='normal' mb='2'>{t('slogan', 'The community media search engine')}</Heading>
               <Center>
                 <Box w={['90vw', '80vw', '600px', '600px']} mt='6'>
-                  <DataSearch
-                    componentId='searchbox'
-                    dataField={['headline', 'description', 'transcript']}
-                    fieldWeights={[5, 2, 1]}
-                    placeholder={t('searchForm.placeholder', 'Search for community media')}
-                    autosuggest
-                    queryFormat='and'
-                    fuzziness={0}
-                    debounce={2000}
-                    value={value}
-                    onChange={(value, triggerQuery, event) => {
-                      setValue(value)
-                    }}
-                    onValueSelected={(value, cause, source) => {
-                      const encoded = encodeURIComponent(value)
-                      history.push(`/search/?searchbox="${encoded}"`)
-                    }}
-                  />
+                  <GoToSearchBox />
                 </Box>
               </Center>
             </Flex>

--- a/frontend/src/comp/player.jsx
+++ b/frontend/src/comp/player.jsx
@@ -323,7 +323,6 @@ function Timeslider (props = {}) {
     py: '2px',
     bg: '#222',
     color: 'white',
-    fontSize: 'xl',
     borderRadius: 'sm',
     fontWeight: 'medium',
     fontSize: 'sm',

--- a/frontend/src/comp/search.jsx
+++ b/frontend/src/comp/search.jsx
@@ -352,6 +352,8 @@ export function ResultItem (props) {
     duration = (item.media[0].duration / 60).toFixed() + ' min'
   }
 
+  const description = React.useMemo(() => stripHTML(item.description), [item.description])
+
   return (
     <Flex
       direction='column'
@@ -400,7 +402,7 @@ export function ResultItem (props) {
           </Flex>
           <Box mt='2'>
             <CollapsedText render={text => <TextWithMarks>{text}</TextWithMarks>}>
-              {item.description}
+              {description}
             </CollapsedText>
           </Box>
         </Flex>
@@ -410,6 +412,21 @@ export function ResultItem (props) {
     </Flex>
   )
 }
+
+function Sanitize (props = {}) {
+  const { children } = props
+  const sanitized = React.useMemo(() => {
+    return stripHTML(children)
+  }, [children])
+  return sanitized || ''
+}
+
+function stripHTML (html) {
+  if (!html) return ''
+  const doc = new DOMParser().parseFromString(html, 'text/html')
+  return doc.body.textContent || ''
+}
+
 
 export function TextWithMarks (props = {}) {
   let { children, text, style = {}, markAs, ...rest } = props


### PR DESCRIPTION
We don't want autosuggests for now, and would also (likely) customize the rendering of the search bar.

This tries to achieve both, by switching the `DataSearch` component to controlled mode, and then hiding it from view, replacing it with Chakra components and forwarding the values between the two.

Please test extensively. 

For me it seems to work well. I once ran into an error when switching around other filters but failed to reproduce.

Please try to provide very detailed steps to reproduce if you find issues (e.g. exactly which clicks to perform in which order).