### PR TITLE
Language-related improvements to elasticsearch mapping

### DIFF
--- a/rust/oas-common/src/types/post.rs
+++ b/rust/oas-common/src/types/post.rs
@@ -153,6 +153,7 @@ impl ElasticMapping for Post {
             },
             "description":{
                 "type":"text",
+                "analyzer": "german",
                 "fields":{
                     "keyword":{
                         "type":"keyword",
@@ -171,6 +172,7 @@ impl ElasticMapping for Post {
             },
             "headline":{
                 "type":"text",
+                "analyzer": "german",
                 "fields":{
                     "keyword":{
                         "type":"keyword",

--- a/rust/oas-common/src/types/post.rs
+++ b/rust/oas-common/src/types/post.rs
@@ -116,12 +116,6 @@ impl ElasticMapping for Post {
             },
             "contentUrl":{
                 "type":"text",
-                "fields":{
-                    "keyword":{
-                        "type":"keyword",
-                        "ignore_above":256
-                    }
-                }
             },
             "contributor":{
                 "properties":{
@@ -154,12 +148,6 @@ impl ElasticMapping for Post {
             "description":{
                 "type":"text",
                 "analyzer": "german",
-                "fields":{
-                    "keyword":{
-                        "type":"keyword",
-                        "ignore_above":256
-                    }
-                }
             },
             "genre":{
                 "type":"text",
@@ -173,12 +161,6 @@ impl ElasticMapping for Post {
             "headline":{
                 "type":"text",
                 "analyzer": "german",
-                "fields":{
-                    "keyword":{
-                        "type":"keyword",
-                        "ignore_above":256
-                    }
-                }
             },
             "identifier":{
                 "type":"keyword",
@@ -212,12 +194,6 @@ impl ElasticMapping for Post {
             },
             "url":{
                 "type":"text",
-                "fields":{
-                    "keyword":{
-                        "type":"keyword",
-                        "ignore_above":256
-                    }
-                }
             },
             "feeds": {
                 "type":"keyword",

--- a/rust/oas-core/src/index/elastic.rs
+++ b/rust/oas-core/src/index/elastic.rs
@@ -520,10 +520,14 @@ pub fn wrap_mapping_properties(properties: serde_json::Value) -> serde_json::Val
                 "analyzer": {
                     "payload_delimiter": {
                         "tokenizer": "whitespace",
-                        "filter": [ "payload_delimiter_filter" ]
+                        "filter": [ "lowercase", "oas_stemmer", "payload_delimiter_filter" ]
                     }
                 },
                 "filter": {
+                    "oas_stemmer": {
+                       "type": "stemmer",
+                       "language": "light_german"
+                    },
                     "payload_delimiter_filter": {
                         "type": "delimited_payload",
                         "delimiter": "|",


### PR DESCRIPTION
  - Set analyzer for headline and description to german
  - Added lowercase and german stemming filters to our custom transcript
    analyzer

For now this is hard coded to German, but could be easily made configurable in the future.

I've tested it and it looks good. Would be great if we could compare it to the old mapping, as we currently have no system for mapping testing this needs to be done manually.

This should fix #35 

This PR also removed a few keyword subfields from the mapping that were unnecessary.