### PR TITLE
fix quirk in docker code to download model

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ docker-compose -f docker-compose.nightly.yml up
 For the speech recognition to work you will need to download the models first. Run this command once, it will download the models into the `./data/oas` volume:
 
 ```sh
-docker-compose exec worker python download_models.py
+docker-compose -f docker-compose.nightly.yml exec worker python download_models.py
 ```
 
 #### Build Docker images from source


### PR DESCRIPTION
if , as supposed above , you download an use docker-compose.nightly.yml , you have to make it explicit _ since docker(-compose) just search for docker-compose.yml. This file wont exist in the "quick-docker-start" suggestion