### PR TITLE
Core: Wait for CouchDB and Elasticsearch to be ready.

### DIFF
--- a/rust/oas-core/src/couch/error.rs
+++ b/rust/oas-core/src/couch/error.rs
@@ -20,6 +20,8 @@ pub enum CouchError {
     Other(String),
     #[error("{0}")]
     MissingRefs(#[from] MissingRefsError),
+    #[error("CouchDB is not reachable")]
+    ServiceUnavailable,
 }
 
 impl CouchError {

--- a/rust/oas-core/src/index/manager.rs
+++ b/rust/oas-core/src/index/manager.rs
@@ -4,7 +4,7 @@
 //! index which stores meta information about the indexing state, most importantly the latest
 //! CouchDB seq that was indexed.
 
-use crate::couch::CouchDB;
+use crate::{couch::CouchDB, util::RetryOpts};
 use anyhow::Context;
 use elasticsearch::Elasticsearch;
 use futures::stream::StreamExt;
@@ -141,7 +141,37 @@ impl IndexManager {
         Ok(manager)
     }
 
+    pub async fn wait_for_ready(&self) -> anyhow::Result<()> {
+        let opts = RetryOpts::with_name("Elasticsearch".into());
+        let mut interval = tokio::time::interval(opts.interval);
+        let name = opts.name.unwrap_or_default();
+        for _i in 0..opts.max_retries {
+            let res = self.client.cat().health().send().await;
+            let url = self.config.url.clone().unwrap_or_default();
+            match res {
+                Ok(res) => {
+                    if res.status_code().is_success() {
+                        return Ok(());
+                    } else {
+                        log::debug!(
+                            "Failed to connect to {} at {}: {}",
+                            name,
+                            url,
+                            res.status_code().canonical_reason().unwrap()
+                        );
+                    }
+                }
+                Err(err) => {
+                    log::debug!("Failed to connect to {} at {}: {}", name, url, err);
+                }
+            }
+            interval.tick().await;
+        }
+        Err(std::io::Error::new(std::io::ErrorKind::TimedOut, "Cannot reac service {}").into())
+    }
+
     pub async fn init(&self, opts: InitOpts) -> anyhow::Result<()> {
+        self.wait_for_ready().await?;
         self.meta_index.index.ensure_index(opts.delete_meta).await?;
         self.post_index.index.ensure_index(opts.delete_data).await?;
         Ok(())

--- a/rust/oas-core/src/util.rs
+++ b/rust/oas-core/src/util.rs
@@ -1,4 +1,9 @@
+use std::time::Duration;
+
 use crate::{Record, TypedValue};
+
+pub const RETRY_INTERVAL: Duration = Duration::from_secs(1);
+pub const MAX_RETRIES: usize = 120;
 
 pub fn debug_print_records<T>(records: &[Record<T>])
 where
@@ -18,4 +23,64 @@ where
         record.typ(),
         record.value.label().unwrap_or_default()
     );
+}
+
+pub struct RetryOpts {
+    pub max_retries: usize,
+    pub name: Option<String>,
+    pub interval: Duration,
+}
+impl Default for RetryOpts {
+    fn default() -> Self {
+        Self {
+            max_retries: MAX_RETRIES,
+            interval: RETRY_INTERVAL,
+            name: None,
+        }
+    }
+}
+impl RetryOpts {
+    pub fn with_name(name: String) -> Self {
+        Self {
+            name: Some(name),
+            ..Default::default()
+        }
+    }
+}
+
+/// Repeat a HTTP request until it returns a successfull status.
+pub async fn wait_for_ready(
+    client: &reqwest::Client,
+    opts: RetryOpts,
+    req_builder: impl Fn() -> Result<reqwest::Request, reqwest::Error>,
+) -> Result<(), std::io::Error> {
+    let mut interval = tokio::time::interval(opts.interval);
+    let name = opts.name.unwrap_or_default();
+    for _i in 0..opts.max_retries {
+        let req = req_builder()
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::Other, format!("{}", err)))?;
+        let url = req.url().to_string();
+        match client.execute(req).await {
+            Ok(res) => {
+                if res.status().is_success() {
+                    return Ok(());
+                } else {
+                    log::warn!(
+                        "Failed to connect to {} at {}: {}",
+                        name,
+                        url,
+                        res.status().canonical_reason().unwrap()
+                    );
+                }
+            }
+            Err(err) => {
+                log::warn!("Failed to connect to {} at {}: {}", name, url, err);
+            }
+        }
+        interval.tick().await;
+    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::TimedOut,
+        "Cannot reach service {}",
+    ))
 }


### PR DESCRIPTION
When starting the backend try connections to the services and if they
fail, retry them for 120 seconds before dying with an
error.

TODO: Make retries configurable.

Fixes #43 