### PR TITLE
add delete_job

### DIFF
--- a/rust/oas-core/src/jobs/mod.rs
+++ b/rust/oas-core/src/jobs/mod.rs
@@ -47,6 +47,10 @@ impl JobManager {
         Ok(job_id)
     }
 
+    pub async fn delete_job(&self, job: JobId) -> anyhow::Result<()>{
+        self.client.delete_job(job).await?;
+        Ok(())
+    }
     pub async fn take_job_timeout(
         &self,
         typ: &str,

--- a/rust/oas-core/src/jobs/ocypod.rs
+++ b/rust/oas-core/src/jobs/ocypod.rs
@@ -47,9 +47,11 @@ impl OcypodClient {
             check_response(&res)?;
             let body: JobInput = res.json().await?;
             Ok(Some(body))
+     
         }
     }
 
+   
     pub async fn update_job(
         &self,
         job_id: JobId,
@@ -82,6 +84,13 @@ impl OcypodClient {
         check_response(&res)?;
         let job: JobInfo = res.json().await?;
         Ok(job)
+    }
+    
+    pub async fn delete_job(&self, job_id: JobId) -> anyhow::Result<()> {
+        let url = format!("{}/job/{}", self.base_url, job_id);
+        let res = self.client.delete(&url).send().await?;
+        check_response(&res)?;
+        Ok(())
     }
 
     pub async fn get_queues(&self) -> anyhow::Result<Vec<String>> {

--- a/rust/oas-core/src/server/handlers/job.rs
+++ b/rust/oas-core/src/server/handlers/job.rs
@@ -2,7 +2,7 @@ use rocket::http::Status;
 use rocket::response::status::Custom;
 use rocket::serde::json::Json;
 use rocket::FromForm;
-use rocket::{get, post, put};
+use rocket::{get, post, put, delete};
 use rocket_okapi::openapi;
 
 use crate::server::auth::AdminUser;
@@ -59,6 +59,18 @@ pub async fn post_job(
 ) -> Result<JobId> {
     let res = state.jobs.create_job(value.into_inner()).await?;
     Ok(Json(res))
+}
+
+/// Delete a job by ID
+#[openapi(skip)]
+#[delete("/job/<id>")]
+pub async fn delete_job(
+    _user: AdminUser,
+    state: &rocket::State<crate::State>,
+    id: u64,
+) -> Result<()> {
+    state.jobs.delete_job(id).await?;
+    Ok(Json(()))
 }
 
 /// Pull a job to work it.

--- a/rust/oas-core/src/server/mod.rs
+++ b/rust/oas-core/src/server/mod.rs
@@ -83,6 +83,7 @@ pub async fn run_server(mut state: State, opts: ServerOpts) -> anyhow::Result<()
                 handlers::job::get_all_jobs,
                 handlers::job::get_job,
                 handlers::job::post_job,
+                handlers::job::delete_job,
                 handlers::job::work_job,
                 handlers::job::put_job_completed,
                 handlers::job::put_job_failed,


### PR DESCRIPTION
It feels very unhandy without the ability to delete jobs with curl. so i added this functionality. 
- [x] add delete function to the jobmanager rust/oas-core/src/jobs/mod.rs
- [x] add delete function to ocypod client rust/oas-core/src/jobs/ocypod.rs
- [x]  add route to rust/oas-core/src/server/handlers/job.rs
- [x] add handler to rust/oas-core/src/server/mod.rs
- [x]  add delete function to frontend job_page  (https://github.com/openaudiosearch/openaudiosearch/pull/78)