### PR TITLE
(wip) Allow to create new jobs on job completion via configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,17 +565,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "elasticsearch-dsl"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7990c3a6b025369a961bd6574c36508377282a2c4b86e15af9a81dc6a1a3a888"
-dependencies = [
- "chrono",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,7 +1203,6 @@ dependencies = [
  "dialoguer",
  "dirs",
  "elasticsearch",
- "elasticsearch-dsl",
  "futures",
  "futures-batch",
  "futures-timer 3.0.2",

--- a/config/jobs.toml
+++ b/config/jobs.toml
@@ -1,0 +1,7 @@
+[[on_complete.asr]]
+job = "recasepunc"
+args = { media_id = "{{args.media_id}}" }
+
+[[on_complete.nlp]]
+job = "naive_ned"
+args = { post_id = "{{args.post_id}}" }

--- a/rust/oas-core/Cargo.toml
+++ b/rust/oas-core/Cargo.toml
@@ -59,3 +59,4 @@ tracing-log = "0.1.2"
 tracing-subscriber = { version = "0.3.1", features = ["env-filter"] }
 url = { version = "2.2", features = ["serde"] }
 uuid = { version = "0.8.2", features = ["v4"] }
+regex = "1.5.4"

--- a/rust/oas-core/src/bin/oas.rs
+++ b/rust/oas-core/src/bin/oas.rs
@@ -305,7 +305,15 @@ async fn run_list(state: State, opts: ListOpts) -> anyhow::Result<()> {
 }
 
 async fn run_debug(_state: State) -> anyhow::Result<()> {
-    eprintln!("OAS debug -- nothing here");
+    let config = crate::jobs::config::JobConfig::load().await;
+    eprintln!("job config {:#?}", config);
+    let config = config?;
+    let args = serde_json::json!({ "media_id": "asdf123" });
+    let on_complete_asr = config.on_complete.get("asr").unwrap().get(0).unwrap();
+    eprintln!("prev job args {}", args);
+    let res = on_complete_asr.template_to_args(&args)?;
+    eprintln!("next job args {}", res);
+    // eprintln!("OAS debug -- nothing here");
     Ok(())
 }
 

--- a/rust/oas-core/src/bin/oas.rs
+++ b/rust/oas-core/src/bin/oas.rs
@@ -304,15 +304,20 @@ async fn run_list(state: State, opts: ListOpts) -> anyhow::Result<()> {
     Ok(())
 }
 
-async fn run_debug(_state: State) -> anyhow::Result<()> {
+async fn run_debug(state: State) -> anyhow::Result<()> {
     let config = crate::jobs::config::JobConfig::load().await;
-    eprintln!("job config {:#?}", config);
     let config = config?;
-    let args = serde_json::json!({ "media_id": "asdf123" });
-    let on_complete_asr = config.on_complete.get("asr").unwrap().get(0).unwrap();
+    let args = serde_json::json!({ "media_id": "tbvj6wf1m3ez5051n2dpkh90p8" });
+    let argfuns = crate::jobs::argfuns::ArgFunctions::with_defaults();
+    let argfun_ctx = crate::jobs::argfuns::ArgFunContext {
+        db: state.db.clone(),
+    };
+    let on_complete_asr = config.on_complete.get("asr").unwrap().get(1).unwrap();
     eprintln!("prev job args {}", args);
-    let res = on_complete_asr.template_to_args(&args)?;
-    eprintln!("next job args {}", res);
+    let res = on_complete_asr
+        .template_to_args(&args, &argfuns, argfun_ctx)
+        .await;
+    eprintln!("next job args {:?}", res);
     // eprintln!("OAS debug -- nothing here");
     Ok(())
 }

--- a/rust/oas-core/src/config.rs
+++ b/rust/oas-core/src/config.rs
@@ -1,0 +1,45 @@
+use dirs::config_dir;
+use serde::de::DeserializeOwned;
+use std::path::Path;
+
+pub const CONFIG_PREFIX: &str = "openaudiosearch";
+
+pub async fn load_config<C>(name: impl ToString, default: Option<&[u8]>) -> anyhow::Result<C>
+where
+    C: DeserializeOwned,
+{
+    let mut locations = vec![];
+    let name = name.to_string();
+    let location = Path::new(CONFIG_PREFIX).join(Path::new(&name));
+    if let Some(dir) = config_dir() {
+        let dir = dir.join(location.clone());
+        locations.push(dir);
+    }
+    locations.push(Path::new("/etc").join(location));
+    eprintln!("locs {:#?}", locations);
+
+    let buf = loop {
+        if let Some(location) = locations.pop() {
+            if let Ok(buf) = tokio::fs::read(&location).await {
+                log::debug!(
+                    "loading config `{}` from file `{}`",
+                    name,
+                    location.display()
+                );
+                break Some(buf);
+            }
+        } else {
+            break None;
+        }
+    };
+    let buf = if buf.is_some() {
+        buf
+    } else {
+        log::debug!("loading config `{}` from default", name);
+        default.map(|buf| buf.to_vec())
+    };
+    let buf =
+        buf.ok_or_else(|| anyhow::anyhow!("No config file found and no default provided."))?;
+    let config: C = toml::from_slice(&buf[..])?;
+    Ok(config)
+}

--- a/rust/oas-core/src/config.rs
+++ b/rust/oas-core/src/config.rs
@@ -16,7 +16,6 @@ where
         locations.push(dir);
     }
     locations.push(Path::new("/etc").join(location));
-    eprintln!("locs {:#?}", locations);
 
     let buf = loop {
         if let Some(location) = locations.pop() {

--- a/rust/oas-core/src/couch/mod.rs
+++ b/rust/oas-core/src/couch/mod.rs
@@ -247,7 +247,7 @@ impl CouchDB {
 
     /// Delete a doc by its id
     pub async fn delete_doc(&self, id: &str) -> Result<PutResponse> {
-        let last_doc = self.get_doc(&id).await;
+        let last_doc = self.get_doc(id).await;
         let mut path = id.to_owned();
         if let Ok(last_doc) = last_doc {
             if let Some(rev) = last_doc.rev() {
@@ -266,7 +266,7 @@ impl CouchDB {
         } else {
             log::trace!("[{}] delete OK for {}", self.config.database, id);
         }
-        return res;
+        res
     }
 
     /// Put a doc into the database.

--- a/rust/oas-core/src/couch/table.rs
+++ b/rust/oas-core/src/couch/table.rs
@@ -26,7 +26,7 @@ where
 
     pub async fn get(&self, id: &str) -> CouchResult<Record<T>> {
         // TODO: Make this clean.
-        let guid = if id.contains("_") {
+        let guid = if id.contains('_') {
             id.to_string()
         } else {
             T::guid(id)

--- a/rust/oas-core/src/index/post_index.rs
+++ b/rust/oas-core/src/index/post_index.rs
@@ -137,14 +137,11 @@ impl PostIndex {
 
         // Resolve all unresolved media references.
         let resolve_result = db.resolve_all_refs(&mut posts.as_mut_slice()).await;
-        match resolve_result {
-            Err(errs) => {
-                log::error!("{}", errs);
-                for err in errs.0 {
-                    log::debug!("  {}", err);
-                }
+        if let Err(errs) = resolve_result {
+            log::error!("{}", errs);
+            for err in errs.0 {
+                log::debug!("  {}", err);
             }
-            _ => {}
         }
 
         for post in posts.iter_mut() {
@@ -191,28 +188,25 @@ fn report_indexing_results(res: &Result<BulkPutResponse, IndexError>) {
         }
         Ok(res) => {
             let stats = res.stats();
-            match res.errors {
-                true => {
-                    log::error!("Index failed for {} docs", stats.errors);
-                    if let Some((id, err)) = stats.first_error {
-                        log::error!(
-                            "First error occured on doc {}: {} {}",
-                            id,
-                            err.r#type,
-                            err.reason
-                        );
-                    }
-
-                    for error in res.errors() {
-                        log::debug!(
-                            "Index fail for doc {}: {} {}",
-                            error.0,
-                            error.1.r#type,
-                            error.1.reason
-                        );
-                    }
+            if res.errors {
+                log::error!("Index failed for {} docs", stats.errors);
+                if let Some((id, err)) = stats.first_error {
+                    log::error!(
+                        "First error occured on doc {}: {} {}",
+                        id,
+                        err.r#type,
+                        err.reason
+                    );
                 }
-                _ => {}
+
+                for error in res.errors() {
+                    log::debug!(
+                        "Index fail for doc {}: {} {}",
+                        error.0,
+                        error.1.r#type,
+                        error.1.reason
+                    );
+                }
             }
         }
     }

--- a/rust/oas-core/src/index/post_index.rs
+++ b/rust/oas-core/src/index/post_index.rs
@@ -245,7 +245,7 @@ fn generate_transcript_token_string(transcript: &Transcript, id: usize) -> Strin
         );
         tokens.push(token);
     }
-    
+
     tokens.join(" ")
 }
 

--- a/rust/oas-core/src/jobs/argfuns.rs
+++ b/rust/oas-core/src/jobs/argfuns.rs
@@ -1,0 +1,74 @@
+use crate::CouchDB;
+use std::collections::HashMap;
+use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
+
+mod defaults;
+
+#[derive(Clone, Debug)]
+pub struct ArgFunContext {
+    pub db: CouchDB,
+}
+
+pub type ArgFun = Box<
+    dyn Fn(
+            ArgFunContext,
+            serde_json::Value,
+        )
+            -> Pin<Box<dyn Future<Output = anyhow::Result<serde_json::Value>> + Send + 'static>>
+        + Send
+        + Sync
+        + 'static,
+>;
+
+#[derive(Default)]
+pub struct ArgFunctions {
+    functions: HashMap<String, ArgFun>,
+}
+
+impl fmt::Debug for ArgFunctions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ArgFunctions({:?})", self.functions.keys())
+    }
+}
+
+impl ArgFunctions {
+    pub fn with_defaults() -> Self {
+        let mut this = Self::default();
+        this.insert_static(
+            "post_id_from_media".to_string(),
+            &defaults::post_id_from_media,
+        );
+        this
+    }
+    pub fn insert(&mut self, name: String, f: ArgFun) {
+        self.functions.insert(name, f);
+    }
+
+    pub fn insert_static<F, R>(&mut self, name: String, f: &'static F)
+    where
+        F: 'static + Send + Sync + Fn(ArgFunContext, serde_json::Value) -> R,
+        R: 'static + Send + Future<Output = anyhow::Result<serde_json::Value>>,
+    {
+        let boxed_fun: ArgFun = Box::new(move |ctx, args| {
+            let r = (f)(ctx, args);
+            Box::pin(async move { r.await })
+        });
+        self.insert(name, boxed_fun);
+    }
+
+    pub async fn apply(
+        &self,
+        ctx: ArgFunContext,
+        name: &str,
+        input: serde_json::Value,
+    ) -> anyhow::Result<serde_json::Value> {
+        let fun = self
+            .functions
+            .get(name)
+            .ok_or_else(|| anyhow::anyhow!("Argument function not found: `{}`", name))?;
+        let res = (fun)(ctx, input).await;
+        res
+    }
+}

--- a/rust/oas-core/src/jobs/argfuns/defaults.rs
+++ b/rust/oas-core/src/jobs/argfuns/defaults.rs
@@ -1,0 +1,21 @@
+use super::*;
+use oas_common::types::{Media, Post};
+
+pub async fn post_id_from_media(
+    ctx: ArgFunContext,
+    args: serde_json::Value,
+) -> anyhow::Result<serde_json::Value> {
+    let db = &ctx.db;
+    let id = args
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("Argument must be a string."))?;
+
+    let record = db.table::<Media>().get(&id).await?;
+    for post_ref in record.value.posts.iter() {
+        let post = db.table::<Post>().get(post_ref.id()).await;
+        if let Ok(post) = post {
+            return Ok(serde_json::Value::String(post.id().to_string()));
+        }
+    }
+    Err(anyhow::anyhow!("Media has no post"))
+}

--- a/rust/oas-core/src/jobs/bin.rs
+++ b/rust/oas-core/src/jobs/bin.rs
@@ -110,10 +110,7 @@ pub async fn load_medias_with_opts(
             .get_all()
             .await?
             .into_iter()
-            .filter_map(|r| match r.value.transcript {
-                None => Some(r),
-                Some(_) => None,
-            })
+            .filter(|r| r.value.transcript.is_none())
             .collect(),
         AsrOpts { latest: true, .. } => db.table::<Media>().get_all().await?,
         _ => {

--- a/rust/oas-core/src/jobs/config.rs
+++ b/rust/oas-core/src/jobs/config.rs
@@ -1,0 +1,72 @@
+use serde::Deserialize;
+use std::collections::HashMap;
+
+// use super::argfuns::{ArgFunContext, ArgFunctions};
+
+const DEFAULT_CONFIG: &'static [u8] = include_bytes!("../../../../config/jobs.toml");
+
+#[derive(Deserialize, Debug, Clone, Default)]
+pub struct JobConfig {
+    pub on_complete: HashMap<String, Vec<StartConfig>>,
+}
+
+impl JobConfig {
+    pub async fn load() -> anyhow::Result<Self> {
+        crate::config::load_config("jobs.toml", Some(DEFAULT_CONFIG)).await
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct StartConfig {
+    pub job: String,
+    pub args: HashMap<String, serde_json::Value>,
+}
+
+impl StartConfig {
+    // pub async fn template_to_args(
+    pub fn template_to_args(
+        &self,
+        args: &serde_json::Value,
+        // argfuns: &ArgFunctions,
+        // argfun_ctx: &ArgFunContext,
+    ) -> anyhow::Result<serde_json::Value> {
+        let mut template = self.args.clone();
+        let input = serde_json::json!({ "args": args });
+        for (_key, value) in template.iter_mut() {
+            match value {
+                serde_json::Value::String(string) => {
+                    if string.starts_with("{{") && string.ends_with("}}") {
+                        let pattern = &string[2..(string.len() - 2)];
+                        let mut parts = pattern.split("|");
+                        let getter = parts.nth(0).unwrap();
+                        // let argfun = parts.nth(1);
+
+                        let replacement = extract_replacement(&input, &getter);
+
+                        if let Some(replacement) = replacement {
+                            // Run argfuns if present.
+                            // let replacement = if let Some(argfun) = argfun {
+                            //     argfuns.apply(&argfun_ctx, argfun, replacement)?
+                            // } else {
+                            //     replacement
+                            // };
+
+                            // Replace the value.
+                            *value = replacement
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(serde_json::to_value(template)?)
+    }
+}
+
+fn extract_replacement(input: &serde_json::Value, pattern: &str) -> Option<serde_json::Value> {
+    let pointer = pattern.replace(".", "/");
+    let pointer = format!("/{}", pointer);
+    let res = input.pointer(&pointer);
+    let res = res.map(|r| r.clone());
+    res
+}

--- a/rust/oas-core/src/jobs/mod.rs
+++ b/rust/oas-core/src/jobs/mod.rs
@@ -47,7 +47,7 @@ impl JobManager {
         Ok(job_id)
     }
 
-    pub async fn delete_job(&self, job: JobId) -> anyhow::Result<()>{
+    pub async fn delete_job(&self, job: JobId) -> anyhow::Result<()> {
         self.client.delete_job(job).await?;
         Ok(())
     }

--- a/rust/oas-core/src/jobs/mod.rs
+++ b/rust/oas-core/src/jobs/mod.rs
@@ -166,9 +166,8 @@ impl JobManager {
 
     async fn on_complete(&self, job: &JobInfo) -> anyhow::Result<()> {
         let typ = &job.queue;
-        match typ.as_str() {
-            typs::ASR => typs::on_asr_complete(&self.db, &self, &job).await?,
-            _ => {}
+        if typ.as_str() == typs::ASR {
+            typs::on_asr_complete(&self.db, self, job).await?;
         }
         Ok(())
     }

--- a/rust/oas-core/src/jobs/ocypod.rs
+++ b/rust/oas-core/src/jobs/ocypod.rs
@@ -47,11 +47,9 @@ impl OcypodClient {
             check_response(&res)?;
             let body: JobInput = res.json().await?;
             Ok(Some(body))
-     
         }
     }
 
-   
     pub async fn update_job(
         &self,
         job_id: JobId,
@@ -85,7 +83,7 @@ impl OcypodClient {
         let job: JobInfo = res.json().await?;
         Ok(job)
     }
-    
+
     pub async fn delete_job(&self, job_id: JobId) -> anyhow::Result<()> {
         let url = format!("{}/job/{}", self.base_url, job_id);
         let res = self.client.delete(&url).send().await?;

--- a/rust/oas-core/src/jobs/typs.rs
+++ b/rust/oas-core/src/jobs/typs.rs
@@ -48,7 +48,6 @@ fn job_setting<T: TypedValue>(record: &Record<T>, typ: &str) -> serde_json::Valu
     record
         .meta()
         .jobs()
-        .setting(typ)
-        .map(|x| x.clone())
+        .setting(typ).cloned()
         .unwrap_or_else(|| serde_json::Value::Object(Default::default()))
 }

--- a/rust/oas-core/src/lib.rs
+++ b/rust/oas-core/src/lib.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use anyhow::Context;
 
+pub mod config;
 pub mod couch;
 // pub mod couch2;
 pub mod index;
@@ -72,6 +73,10 @@ impl State {
             .init(Default::default())
             .await
             .context("Failed to initialize Elasticsearch.")?;
+        self.jobs
+            .init()
+            .await
+            .context("Failed to initialize job manager")?;
         Ok(())
     }
 }

--- a/rust/oas-core/src/rss/mapping.rs
+++ b/rust/oas-core/src/rss/mapping.rs
@@ -4,14 +4,14 @@ use toml;
 extern crate dirs;
 use anyhow::Context;
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio::fs::{metadata, read_to_string};
 
 pub type AllMappings = HashMap<String, String>;
 
 const DEFAULT_MAPPING: &str = include_str!("../../../../config/mapping.toml");
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct MappingManager {
     mappings: HashMap<String, Mapping>,
     path: Option<PathBuf>,
@@ -30,10 +30,7 @@ pub struct FieldMapping {
 
 impl MappingManager {
     pub fn new() -> Self {
-        Self {
-            mappings: Default::default(),
-            path: None,
-        }
+        Self::default()
     }
 
     pub fn with_file(f: &str) -> Self {
@@ -94,15 +91,14 @@ async fn mapping_path() -> Option<PathBuf> {
     None
 }
 
-async fn path_exists(path: &PathBuf) -> bool {
-    let path = path.clone();
+async fn path_exists(path: &Path) -> bool {
     let metadata = match metadata(&path).await {
         Ok(metadata) => metadata.is_file(),
         Err(e) => {
             log::debug!(
                 "{} on path: {}",
                 e,
-                path.into_os_string().into_string().unwrap()
+                path.as_os_str().to_str().unwrap_or_default()
             );
             false
         }

--- a/rust/oas-core/src/server/auth/mod.rs
+++ b/rust/oas-core/src/server/auth/mod.rs
@@ -229,7 +229,7 @@ pub async fn get_login(session: Option<SessionInfo>) -> Json<LoginResponse> {
     match session {
         Some(session) => Json(LoginResponse {
             ok: true,
-            user: Some(session.user().into_public()),
+            user: Some(session.user().to_public()),
         }),
         None => Json(LoginResponse {
             ok: false,
@@ -249,7 +249,7 @@ pub async fn post_login(
     let session_id = try_login(auth, cookies, &data, session_id.as_ref()).await;
     if let Some(session_id) = session_id {
         let session = auth.session(&session_id.0).await.unwrap();
-        let public_user_info = session.user().into_public();
+        let public_user_info = session.user().to_public();
         Json(LoginResponse {
             ok: true,
             user: Some(public_user_info),

--- a/rust/oas-core/src/server/auth/password.rs
+++ b/rust/oas-core/src/server/auth/password.rs
@@ -6,10 +6,7 @@ use lazy_static::lazy_static;
 use rand_core::OsRng;
 
 lazy_static! {
-    static ref SALT: SaltString = {
-        
-        SaltString::generate(&mut OsRng)
-    };
+    static ref SALT: SaltString = SaltString::generate(&mut OsRng);
 }
 
 lazy_static! {

--- a/rust/oas-core/src/server/auth/sessions.rs
+++ b/rust/oas-core/src/server/auth/sessions.rs
@@ -44,10 +44,7 @@ impl Sessions {
     }
 
     pub async fn get(&self, session_id: &str) -> Option<Arc<SessionInfo>> {
-        self.sessions
-            .read()
-            .await
-            .get(session_id).cloned()
+        self.sessions.read().await.get(session_id).cloned()
     }
 
     pub async fn remove(&self, session_id: &str) {

--- a/rust/oas-core/src/server/auth/structs.rs
+++ b/rust/oas-core/src/server/auth/structs.rs
@@ -38,7 +38,7 @@ pub struct LoginResponse {
 }
 
 impl UserInfo {
-    pub fn into_public(&self) -> UserPublicInfo {
+    pub fn to_public(&self) -> UserPublicInfo {
         self.clone().into()
     }
 }

--- a/rust/oas-core/src/server/error.rs
+++ b/rust/oas-core/src/server/error.rs
@@ -71,22 +71,19 @@ impl<'r> Responder<'r, 'static> for AppError {
             Err(res) => Err(res),
             Ok(mut res) => {
                 res.set_status(code);
-                match self {
-                    Self::Unauthorized => {
-                        // TODO: This is nice as it makes the API accessible in regular browsers.
-                        // However, this also makes logout basically "not work" because browsers
-                        // remember the basic auth details by default and re-add them.
-                        let header_value = format!(
-                            r#"Basic realm="{}", charset="UTF-8""#,
-                            "Please enter user username and password"
-                        );
-                        let header = rocket::http::Header::new(
-                            http::header::WWW_AUTHENTICATE.as_str(),
-                            header_value,
-                        );
-                        res.set_header(header);
-                    }
-                    _ => {}
+                if let Self::Unauthorized = self {
+                    // TODO: This is nice as it makes the API accessible in regular browsers.
+                    // However, this also makes logout basically "not work" because browsers
+                    // remember the basic auth details by default and re-add them.
+                    let header_value = format!(
+                        r#"Basic realm="{}", charset="UTF-8""#,
+                        "Please enter user username and password"
+                    );
+                    let header = rocket::http::Header::new(
+                        http::header::WWW_AUTHENTICATE.as_str(),
+                        header_value,
+                    );
+                    res.set_header(header);
                 }
                 Ok(res)
             }

--- a/rust/oas-core/src/server/handlers/feed.rs
+++ b/rust/oas-core/src/server/handlers/feed.rs
@@ -1,6 +1,6 @@
 use oas_common::{types, util, Record, TypedValue};
 use rocket::serde::json::Json;
-use rocket::{get, post, put, delete};
+use rocket::{delete, get, post, put};
 use rocket_okapi::openapi;
 
 use crate::couch::types::PutResponse;

--- a/rust/oas-core/src/server/handlers/job.rs
+++ b/rust/oas-core/src/server/handlers/job.rs
@@ -2,7 +2,7 @@ use rocket::http::Status;
 use rocket::response::status::Custom;
 use rocket::serde::json::Json;
 use rocket::FromForm;
-use rocket::{get, post, put, delete};
+use rocket::{delete, get, post, put};
 use rocket_okapi::openapi;
 
 use crate::server::auth::AdminUser;

--- a/rust/oas-core/src/server/handlers/post.rs
+++ b/rust/oas-core/src/server/handlers/post.rs
@@ -47,8 +47,8 @@ pub async fn post_post_batch(
         .map(|mut value| {
             let id = value.identifier.unwrap_or_else(util::id_from_uuid);
             value.identifier = Some(id.clone());
-            let record = Record::from_id_and_value(id, value);
-            record
+            
+            Record::from_id_and_value(id, value)
         })
         .collect::<Vec<_>>();
     let res = state.db.put_record_bulk(records).await?;

--- a/rust/oas-core/src/server/handlers/record.rs
+++ b/rust/oas-core/src/server/handlers/record.rs
@@ -3,7 +3,6 @@ use oas_common::{TypedValue, UntypedRecord};
 use rocket::serde::json::Json;
 use rocket::{get, post};
 use rocket_okapi::openapi;
-use serde_json::Value;
 
 use crate::couch::Doc;
 use crate::server::auth::AdminUser;

--- a/rust/oas-core/src/server/mod.rs
+++ b/rust/oas-core/src/server/mod.rs
@@ -36,7 +36,8 @@ pub async fn run_server(mut state: State, opts: ServerOpts) -> anyhow::Result<()
         ));
 
     // TODO: Don't do this default.
-    let admin_password = &std::env::var("OAS_ADMIN_PASSWORD").unwrap_or("password".to_string());
+    let admin_password =
+        &std::env::var("OAS_ADMIN_PASSWORD").unwrap_or_else(|_| "password".to_string());
 
     let cors = rocket_cors::CorsOptions::default().to_cors()?;
     let auth = auth::Auth::new();

--- a/rust/oas-core/src/server/proxy.rs
+++ b/rust/oas-core/src/server/proxy.rs
@@ -118,18 +118,18 @@ pub struct ProxyHandler {
     rank: isize,
 }
 
-impl Into<Vec<Route>> for ProxyHandler {
-    fn into(self) -> Vec<Route> {
+impl From<ProxyHandler> for Vec<Route> {
+    fn from(proxy: ProxyHandler) -> Self {
         let mut routes = vec![
-            Route::ranked(self.rank, Method::Get, "/<path..>", self.clone()),
-            Route::ranked(self.rank, Method::Put, "/<path..>", self.clone()),
-            Route::ranked(self.rank, Method::Post, "/<path..>", self.clone()),
-            Route::ranked(self.rank, Method::Patch, "/<path..>", self.clone()),
-            Route::ranked(self.rank, Method::Head, "/<path..>", self.clone()),
-            Route::ranked(self.rank, Method::Delete, "/<path..>", self.clone()),
+            Route::ranked(proxy.rank, Method::Get, "/<path..>", proxy.clone()),
+            Route::ranked(proxy.rank, Method::Put, "/<path..>", proxy.clone()),
+            Route::ranked(proxy.rank, Method::Post, "/<path..>", proxy.clone()),
+            Route::ranked(proxy.rank, Method::Patch, "/<path..>", proxy.clone()),
+            Route::ranked(proxy.rank, Method::Head, "/<path..>", proxy.clone()),
+            Route::ranked(proxy.rank, Method::Delete, "/<path..>", proxy.clone()),
         ];
         for route in routes.iter_mut() {
-            route.name = Some(format!("Proxy({})", self.target).into());
+            route.name = Some(format!("Proxy({})", proxy.target).into());
         }
         routes
     }

--- a/rust/oas-core/src/server/static_dir.rs
+++ b/rust/oas-core/src/server/static_dir.rs
@@ -22,9 +22,9 @@ impl IncludedStaticDir {
     }
 }
 
-impl Into<Vec<Route>> for IncludedStaticDir {
-    fn into(self) -> Vec<Route> {
-        let mut route = Route::ranked(self.rank, Method::Get, "/<path..>", self);
+impl From<IncludedStaticDir> for Vec<Route> {
+    fn from(included_dir: IncludedStaticDir) -> Self {
+        let mut route = Route::ranked(included_dir.rank, Method::Get, "/<path..>", included_dir);
         route.name = Some("IncludedStaticDir".to_string().into());
         vec![route]
     }


### PR DESCRIPTION
This adds a way to trigger new jobs when jobs complete. It allows to map arguments of the original job onto the new job. It also allows to register (via Rust code) functions that may be invoked during the mapping from old to new args.

The same should be possible for `output`s of the job (but is not yet implemented). 